### PR TITLE
Disable floating placeholder in Angular 6+

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -10,7 +10,7 @@
 <div class="container mat-elevation-z8">
 
   <div class="form">
-    <mat-form-field floatPlaceholder="never" color="accent">
+    <mat-form-field floatLabel="never" color="accent">
       <input matInput #filter placeholder="Filter issues">
     </mat-form-field>
   </div>


### PR DESCRIPTION
floatPlaceholder="never"  is no longer working in Angular 6+. It is replaced by floatLabel="never"